### PR TITLE
Add IgnoreFetchErrors option

### DIFF
--- a/mailmover/config_sample.dhall
+++ b/mailmover/config_sample.dhall
@@ -1,9 +1,10 @@
-{ IMAPHost       = "imap.example.org:993"
-, SMTPHost       = "smtp.example.org:587"
-, Mailbox        = "INBOX"
-, TrashMailbox   = "Papierkorb"
-, From           = "banana@example.org"
-, FromName       = "Bana Na"
-, Login          = { Username = "banana@example.org", Password = "hunter2" }
-, Rules          = [ { From = ".*", To = "apple@example.org", RewriteFrom = True } ]
+{ IMAPHost          = "imap.example.org:993"
+, SMTPHost          = "smtp.example.org:587"
+, Mailbox           = "INBOX"
+, TrashMailbox      = "Papierkorb"
+, From              = "banana@example.org"
+, FromName          = "Bana Na"
+, Login             = { Username = "banana@example.org", Password = "hunter2" }
+, Rules             = [ { From = ".*", To = "apple@example.org", RewriteFrom = True } ]
+, IgnoreFetchErrors = False
 }


### PR DESCRIPTION
Introduces a new option `IgnoreFetchErrors` to the config file, that makes mailmover print a warning instead of crashing when it can't fetch messages from the mailserver, but was successfully able to select the mailbox. This is necessary, bevause some mailservers, such as the one <https://mailbox.org> is using return a fetch error when a client tries to fetch mails from an empty mailbox